### PR TITLE
Schedule Course Details Page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,6 +68,10 @@ Future<void> main() async {
     return ScheduleCoursePage(courseID: params!["courseID"][0]);
   }));
 
+  router.define("/maps/buildings/:buildingID", handler: Handler(handlerFunc: (BuildContext? context, Map<String, dynamic>? params) {
+    return Placeholder();
+  }));
+
   router.define("/profile", handler: Handler(handlerFunc: (BuildContext? context, Map<String, dynamic>? params) {
     return const ProfilePage();
   }));

--- a/lib/pages/schedule/schedule_course_page.dart
+++ b/lib/pages/schedule/schedule_course_page.dart
@@ -1,7 +1,13 @@
+import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
+import 'package:fuzzywuzzy/fuzzywuzzy.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:mapbox_gl/mapbox_gl.dart';
+import 'package:storke_central/models/building.dart';
 import 'package:storke_central/models/user_schedule_item.dart';
 import 'package:storke_central/utils/config.dart';
 import 'package:storke_central/utils/logger.dart';
+import 'package:storke_central/utils/theme.dart';
 
 class ScheduleCoursePage extends StatefulWidget {
   String courseID = "";
@@ -15,6 +21,8 @@ class _ScheduleCoursePageState extends State<ScheduleCoursePage> {
 
   String courseID = "";
   List<UserScheduleItem> scheduleItems = [];
+  List<Building> scheduleBuildings = [];
+  MapboxMapController? mapController;
 
   _ScheduleCoursePageState(this.courseID);
 
@@ -33,6 +41,73 @@ class _ScheduleCoursePageState extends State<ScheduleCoursePage> {
       }
     }
     log("Found ${scheduleItems.length} schedule items for this course");
+    getBuildings();
+  }
+
+  void getBuildings() {
+    for (UserScheduleItem item in scheduleItems) {
+      setState(() {
+        scheduleBuildings.add(extractOne(
+          query: item.building,
+          choices: buildings,
+          cutoff: 50,
+          getter: (Building b) => b.id,
+        ).choice);
+      });
+    }
+    // Delay to allow map to load
+    Future.delayed(const Duration(milliseconds: 200)).then((value) => addBuildingsToMap());
+  }
+
+  void addBuildingsToMap() {
+    for (Building b in scheduleBuildings) {
+      mapController?.addSymbol(
+        SymbolOptions(
+          textField: "lol",
+          geometry: LatLng(b.latitude, b.longitude),
+          iconSize: 1.5,
+          iconOffset: const Offset(0, -10),
+          iconImage: getBuildingTypeIcon(b.type),
+        ),
+      );
+    }
+    mapController?.animateCamera(
+      CameraUpdate.newCameraPosition(
+        CameraPosition(
+          target: LatLng((scheduleBuildings.first.latitude + scheduleBuildings.last.latitude) / 2, (scheduleBuildings.first.longitude + scheduleBuildings.last.longitude) / 2),
+          zoom: Geolocator.distanceBetween(scheduleBuildings.first.latitude, scheduleBuildings.first.longitude, scheduleBuildings.last.latitude, scheduleBuildings.last.longitude) < 500 ? 16 : 14,
+        ),
+      ),
+    );
+  }
+
+  String getBuildingTypeIcon(String type) {
+    switch (type) {
+      case "Research Laboratory":
+        return "images/markers/lab-marker.png";
+      case "Trailer":
+        return "images/markers/trailer-marker.png";
+      case "Dining Hall":
+        return "images/markers/dining-marker.png";
+      case "Recreation":
+        return "images/markers/recreation-marker.png";
+      default:
+        return "images/markers/building-marker.png";
+    }
+  }
+
+  List<String> getListFromDayString(String days) {
+    List<String> daysList = [];
+    if (days.contains("M")) daysList.add("Monday");
+    if (days.contains("T")) daysList.add("Tuesday");
+    if (days.contains("W")) daysList.add("Wednesday");
+    if (days.contains("R")) daysList.add("Thursday");
+    if (days.contains("F")) daysList.add("Friday");
+    return daysList;
+  }
+
+  void _onMapCreated(MapboxMapController controller) {
+    mapController = controller;
   }
 
   @override
@@ -44,12 +119,60 @@ class _ScheduleCoursePageState extends State<ScheduleCoursePage> {
               style: const TextStyle(fontWeight: FontWeight.bold)
           ),
         ),
-        body: Padding(
+        body: SingleChildScrollView(
           padding: const EdgeInsets.all(8.0),
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(scheduleItems.first.description.split("\n")[0], style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold), textAlign: TextAlign.center,),
-              const Padding(padding: EdgeInsets.all(8),),
+              Text(scheduleItems.first.description.split("\n")[0], style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold)),
+              const Padding(padding: EdgeInsets.all(4),),
+              Text(scheduleItems.first.description.split("\n")[1], style: const TextStyle()),
+              const Padding(padding: EdgeInsets.all(4),),
+              SizedBox(
+                height: 250,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: MapboxMap(
+                    accessToken: MAPBOX_ACCESS_TOKEN,
+                    onMapCreated: _onMapCreated,
+                    initialCameraPosition: const CameraPosition(
+                      target: LatLng(34.412278, -119.847787),
+                      zoom: 14.0,
+                    ),
+                    dragEnabled: false,
+                  ),
+                ),
+              ),
+              const Padding(padding: EdgeInsets.all(4),),
+              Column(
+                children: scheduleItems.map((e) => Card(
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(8),
+                    onTap: () {
+                      router.navigateTo(context, "/maps/buildings/${scheduleBuildings[scheduleItems.indexOf(e)].id}", transition: TransitionType.native);
+                    },
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text("${scheduleItems.indexOf(e) == 0 ? "Lecture" : "Section"} (${e.startTime} - ${e.endTime})", style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                                Text("${scheduleBuildings[scheduleItems.indexOf(e)].name} ${e.room}", style: TextStyle(color: SB_NAVY)),
+                                Text(getListFromDayString(e.days).join(", "), style: const TextStyle()),
+                              ],
+                            ),
+                          ),
+                          const Icon(Icons.arrow_forward_ios_rounded, color: Colors.grey),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ).toList()
+              )
             ],
           ),
         )

--- a/lib/utils/config.dart
+++ b/lib/utils/config.dart
@@ -20,8 +20,8 @@ Version appVersion = Version("2.2.6+1");
 
 // ignore: non_constant_identifier_names
 // String API_HOST = "https://api.storkecentr.al";
-// String API_HOST = "http://localhost:4001";
-String API_HOST = "https://7c24-169-231-9-220.ngrok.io";
+String API_HOST = "http://localhost:4001";
+// String API_HOST = "https://7c24-169-231-9-220.ngrok.io";
 // ignore: non_constant_identifier_names
 String SC_API_KEY = "sc-api-key";
 // ignore: non_constant_identifier_names


### PR DESCRIPTION
Added details page for the schedule items on the schedule page.
- course details
- lecture/section time info
- map location
- map pins/animation to viewpoint supports both single lecture and lecture+section courses
- map page deep linking (TODO from maps page end)

<img width="715" alt="CleanShot 2023-01-13 at 22 24 20@2x" src="https://user-images.githubusercontent.com/33289435/212459033-3ef632dc-a53f-45cb-8e4b-18f2c8f6e915.png">